### PR TITLE
Rearrange linked chest-to-hopper logic

### DIFF
--- a/ChestsPlusPlus_Main/src/main/java/com/jamesdpeters/minecraft/chests/filters/HopperFilter.java
+++ b/ChestsPlusPlus_Main/src/main/java/com/jamesdpeters/minecraft/chests/filters/HopperFilter.java
@@ -38,6 +38,10 @@ public class HopperFilter {
         return filters;
     }
 
+    public static boolean hasFilters(Block block) {
+        return getHopperFilters(block).size() > 0;
+    }
+
     public static boolean isInFilter(Block block, ItemStack itemStack) {
         return isInFilter(getHopperFilters(block), itemStack);
     }

--- a/ChestsPlusPlus_Main/src/main/java/com/jamesdpeters/minecraft/chests/listeners/HopperFilterListener.java
+++ b/ChestsPlusPlus_Main/src/main/java/com/jamesdpeters/minecraft/chests/listeners/HopperFilterListener.java
@@ -36,6 +36,8 @@ public class HopperFilterListener implements Listener {
     public void onHopperMoveEvent(InventoryMoveItemEvent event) {
         //TO HOPPER
         if(event.getDestination().getHolder() instanceof Hopper){
+            if(!HopperFilter.hasFilters(event.getDestination().getLocation().getBlock())) return;
+
             if(event.getDestination().getLocation() != null){
                 // If the event is cancelled by other plugin
                 if(event.isCancelled()) return;
@@ -49,7 +51,8 @@ public class HopperFilterListener implements Listener {
 
             // Item shouldn't be allowed
             if (event.isCancelled() && ServerType.getType() == ServerType.Type.PAPER) {
-                int index = event.getSource().first(event.getItem());
+                int index = event.getSource().first(event.getItem().getType());
+
                 int hopperAmount = SpigotConfig.getWorldSettings(event.getSource().getLocation()).getHopperAmount();
 
                 // Loop over the inventory until next item is found, if no item found return.
@@ -76,7 +79,7 @@ public class HopperFilterListener implements Listener {
     @EventHandler(priority = EventPriority.HIGH)
     public void fromHopper(InventoryMoveItemEvent event){
         //FROM HOPPER
-        if (event.getInitiator().getHolder() instanceof Hopper) {
+        if (event.getSource().getHolder() instanceof Hopper) {
             Location location = event.getDestination().getLocation();
             ChestLinkStorageType storageType = Config.getChestLink();
             if (storageType == null) return;

--- a/ChestsPlusPlus_Main/src/main/java/com/jamesdpeters/minecraft/chests/listeners/LinkedChestHopperListener.java
+++ b/ChestsPlusPlus_Main/src/main/java/com/jamesdpeters/minecraft/chests/listeners/LinkedChestHopperListener.java
@@ -19,7 +19,7 @@ public class LinkedChestHopperListener implements Listener {
     @EventHandler(priority = EventPriority.HIGH)
     public void fromHopper(InventoryMoveItemEvent event) {
         //FROM HOPPER
-        if (event.getInitiator().getHolder() instanceof Hopper) {
+        if (event.getSource().getHolder() instanceof Hopper) {
             Location location = event.getDestination().getLocation();
             if (location == null) return;
             if (!Utils.isLocationChunkLoaded(location)) return;

--- a/ChestsPlusPlus_Main/src/main/java/com/jamesdpeters/minecraft/chests/runnables/VirtualChestToHopper.java
+++ b/ChestsPlusPlus_Main/src/main/java/com/jamesdpeters/minecraft/chests/runnables/VirtualChestToHopper.java
@@ -1,7 +1,6 @@
 package com.jamesdpeters.minecraft.chests.runnables;
 
 import com.jamesdpeters.minecraft.chests.ChestsPlusPlus;
-import com.jamesdpeters.minecraft.chests.filters.HopperFilter;
 import com.jamesdpeters.minecraft.chests.misc.Utils;
 import com.jamesdpeters.minecraft.chests.serialize.LocationInfo;
 import com.jamesdpeters.minecraft.chests.serialize.SpigotConfig;
@@ -36,6 +35,8 @@ public class VirtualChestToHopper extends BukkitRunnable {
                 if (location.getLocation() != null) {
                     if (!Utils.isLocationChunkLoaded(location.getLocation()) || !location.getLocation().getChunk().isEntitiesLoaded())
                         continue;
+                    if(storage.getInventory().isEmpty()) continue;
+
                     Location below = location.getLocation().clone().subtract(0, 1, 0);
                     if (below.getBlock().getState() instanceof Hopper hopper) {
                         if (below.getBlock().isBlockIndirectlyPowered() || below.getBlock().isBlockPowered()) {
@@ -53,6 +54,6 @@ public class VirtualChestToHopper extends BukkitRunnable {
 
     public static boolean move(Location targetLocation, Inventory source, Inventory target) {
         int hopperAmount = SpigotConfig.getWorldSettings(targetLocation.getWorld()).getHopperAmount();
-        return Utils.hopperMove(source, hopperAmount, target, HopperFilter.getHopperFilters(targetLocation.getBlock()));
+        return Utils.hopperMove(source, hopperAmount, target);
     }
 }


### PR DESCRIPTION
The existing logic for pushing items from linked chests to hoppers did not work with other plugins that manipulate hoppers. With these changes, the features in this plugin (linked chests, and hoppers filtered with item frames) behave the same as they did before, BUT they will also correctly interact with other plugins, as a InventoryMoveItemEvent is properly fired (and cancellable) when an item moves from a linked chest into a hopper.

Happy to make adjustments if any of this doesn't jive with how you'd like to do things, and also understand if you don't care about these changes, but since I made them I figured I'd at least offer them up in case you do.